### PR TITLE
feat: Simple feature flag system + use YouTube OEmbed as search query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# anything in Lavalink
+Lavalink/
+
 # Misc
 .DS_Store
 keywords.txt
@@ -167,3 +170,4 @@ keywords-*.txt
 config.json
 *.jar
 notes.*
+Assets/feature_flags.json

--- a/Extensions/FeatureFlagManager.py
+++ b/Extensions/FeatureFlagManager.py
@@ -1,0 +1,82 @@
+from ast import alias
+from encodings import aliases
+import logging
+from discord.ext import commands
+
+from Replies.Strings import Messages
+
+from Suica import Bot
+
+log = logging.getLogger(__name__)
+
+class FeatureFlagManager(commands.Cog):
+	
+	def __init__(self, bot: Bot):
+		self.bot = bot
+
+	@commands.is_owner()
+	@commands.command(name='flags', aliases=['fl'])
+	async def _flags(self, ctx: commands.Context):
+		"""
+		List all the flags!
+		"""
+
+		await ctx.typing()
+
+		flags = self.bot.feature_flags.list_all()
+
+		if not flags:
+			await ctx.message.add_reaction('🈳')
+			return
+		
+		lines = []
+		for flag, enabled in flags.items():
+			status = '⭕' if enabled else '❌'
+			lines.append(f"{flag} : {status}")
+
+		await ctx.send(f'\n'.join(lines))
+
+	@commands.is_owner()
+	@commands.command(name='flagon', aliases=['flon', 'fon', 'on'])
+	async def _flag_on(self, ctx: commands.Context, flag: str):
+		"""
+		Enable a flag
+		"""
+		if self.bot.feature_flags.enable(flag):
+			await ctx.send(Messages.FEATURE_FLAG_ON.format(flag))
+		else:
+			await ctx.send(Messages.FEATURE_FLAG_NOT_FOUND.format(flag))
+
+	@commands.is_owner()
+	@commands.command(name='flagoff', aliases=['floff', 'foff', 'off'])
+	async def _flag_off(self, ctx: commands.Context, flag: str):
+		"""
+		Disable a flag
+		"""
+		if self.bot.feature_flags.disable(flag):
+			await ctx.send(Messages.FEATURE_FLAG_OFF.format(flag))
+		else:
+			await ctx.send(Messages.FEATURE_FLAG_NOT_FOUND.format(flag))
+
+	# @commands.is_owner()
+	@commands.command(name='flagtoggle', aliases=['fltoggle', 'ftoggle', 'toggle', 'tog'])
+	async def _flag_toggle(self, ctx: commands.Context, flag: str):
+		"""
+		Toggle a flag
+		"""
+		new_flag_state = self.bot.feature_flags.toggle(flag)
+
+		if new_flag_state is None:
+			await ctx.send(Messages.FEATURE_FLAG_NOT_FOUND.format(flag))
+		else:
+			if new_flag_state == True:
+				await ctx.send(Messages.FEATURE_FLAG_ON.format(flag))
+			else:
+				await ctx.send(Messages.FEATURE_FLAG_OFF.format(flag))
+	
+async def setup(bot: Bot):
+	await bot.add_cog(FeatureFlagManager(bot))
+	log.info("Module loaded")
+       
+	
+	  

--- a/Extensions/Jukebox.py
+++ b/Extensions/Jukebox.py
@@ -3,6 +3,7 @@ import discord
 from discord.ext import commands
 from Extensions.JukeboxHelpers.Errors import *
 from Extensions.JukeboxHelpers.Player import Player
+from Extensions.JukeboxHelpers.OEmbed import fetch_youtube_oembed, OEmbedFetchError
 from Replies.Strings import Messages
 from Replies.Embeds import JukeboxEmbeds
 from Replies.Embeds import (
@@ -10,6 +11,8 @@ from Replies.Embeds import (
 )  # TODO: Consider refactoring this to a separate module
 
 import wavelink
+
+from Suica import Bot
 
 # logging
 log = logging.getLogger(__name__)
@@ -20,7 +23,7 @@ The main command interface for the jukebox.
 
 
 class Jukebox(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: Bot):
         self.bot = bot
         self.node = None
 
@@ -145,7 +148,8 @@ class Jukebox(commands.Cog):
 
         player: Player = await self.get_player(ctx)
 
-        # pre-process the query
+        # strip <> away in case someone knows that adding these removed link embeds
+        # (which is unlikely lol)
         processed_query = query.strip("<>")
 
         # process and give an extra message when adding a song from YT's playlist view.
@@ -159,8 +163,32 @@ class Jukebox(commands.Cog):
             )
 
         # perform the query
-        await ctx.send(Messages.JUKEBOX_SEARCHING.format(processed_query))
+        query_processing_msg = await ctx.send(Messages.JUKEBOX_SEARCHING.format(processed_query))
         await ctx.typing()  # typing indicator for UX
+
+        # oEmbed workaround for direct YouTube URLs (not playlists)
+        # this workaround gets the video's title and author first, then stiches them together as the new query
+        # then do a keyword search with the new query instead
+        # this is here since search still works but direct url broke for Lavalink now :/
+        if self.bot.feature_flags.is_enabled('yt_url_workaround'):
+            is_youtube_url = "youtube.com" in processed_query or "youtu.be" in processed_query
+            is_playlist = "&list=" in processed_query or "/playlist?" in processed_query
+            
+            if is_youtube_url and not is_playlist:
+                try:
+                    oembed_info = await fetch_youtube_oembed(processed_query)
+                    log.info(f"oEmbed info: {oembed_info}")
+
+                    new_query = f"{oembed_info['title']} - {oembed_info['author']}"
+                    old_query = processed_query
+                    
+                    processed_query = new_query
+                    
+                    # send updated message i.e. old query -> new query
+                    await query_processing_msg.edit(content=Messages.JUKEBOX_SEARCHING.format(f"{old_query} ➡️ {new_query}"))
+                except OEmbedFetchError as e:
+                    log.warning(f"oEmbed fetch failed: {e}")
+                    await ctx.send(Messages.YT_WORKAROUND_OEMBED_FETCH_FAILED)
 
         tracks = await wavelink.Playable.search(
             processed_query, source=wavelink.TrackSource.YouTube

--- a/Extensions/Jukebox.py
+++ b/Extensions/Jukebox.py
@@ -171,6 +171,7 @@ class Jukebox(commands.Cog):
         # then do a keyword search with the new query instead
         # this is here since search still works but direct url broke for Lavalink now :/
         if self.bot.feature_flags.is_enabled('yt_url_workaround'):
+            log.info("YT URL workaround engaged")
             is_youtube_url = "youtube.com" in processed_query or "youtu.be" in processed_query
             is_playlist = "&list=" in processed_query or "/playlist?" in processed_query
             

--- a/Extensions/Jukebox.py
+++ b/Extensions/Jukebox.py
@@ -186,7 +186,7 @@ class Jukebox(commands.Cog):
                     processed_query = new_query
                     
                     # send updated message i.e. old query -> new query
-                    await query_processing_msg.edit(content=Messages.JUKEBOX_SEARCHING.format(f"{old_query} ➡️ {new_query}"))
+                    await query_processing_msg.edit(content=Messages.JUKEBOX_SEARCHING_WORKAROUND.format(old_query, new_query))
                 except OEmbedFetchError as e:
                     log.warning(f"oEmbed fetch failed: {e}")
                     await ctx.send(Messages.YT_WORKAROUND_OEMBED_FETCH_FAILED)

--- a/Extensions/JukeboxHelpers/OEmbed.py
+++ b/Extensions/JukeboxHelpers/OEmbed.py
@@ -1,6 +1,7 @@
 import asyncio
 import aiohttp
 import logging
+import socket
 from urllib.parse import quote
 
 log = logging.getLogger(__name__)
@@ -32,7 +33,8 @@ async def fetch_youtube_oembed(url: str) -> dict:
     try:
         log.info("[OEmbed] Creating aiohttp session...")
         timeout = aiohttp.ClientTimeout(total=10)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
+        connector = aiohttp.TCPConnector(family=socket.AF_INET)  # Force IPv4
+        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
             log.info("[OEmbed] Sending GET request (10s timeout)...")
             async with session.get(oembed_url) as response:
                 log.info(f"[OEmbed] Response status: {response.status}")

--- a/Extensions/JukeboxHelpers/OEmbed.py
+++ b/Extensions/JukeboxHelpers/OEmbed.py
@@ -1,3 +1,4 @@
+import asyncio
 import aiohttp
 import logging
 from urllib.parse import quote
@@ -30,8 +31,9 @@ async def fetch_youtube_oembed(url: str) -> dict:
 
     try:
         log.info("[OEmbed] Creating aiohttp session...")
-        async with aiohttp.ClientSession() as session:
-            log.info("[OEmbed] Sending GET request...")
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            log.info("[OEmbed] Sending GET request (10s timeout)...")
             async with session.get(oembed_url) as response:
                 log.info(f"[OEmbed] Response status: {response.status}")
                 log.info(f"[OEmbed] Response headers: {dict(response.headers)}")
@@ -52,6 +54,9 @@ async def fetch_youtube_oembed(url: str) -> dict:
                 }
                 log.info(f"[OEmbed] Parsed result: {result}")
                 return result
+    except asyncio.TimeoutError as e:
+        log.exception("[OEmbed] Request timed out after 10 seconds")
+        raise OEmbedFetchError("Request timed out after 10 seconds") from e
     except aiohttp.ClientError as e:
         log.exception(f"[OEmbed] aiohttp ClientError: {e}")
         raise OEmbedFetchError(f"Network error: {e}") from e

--- a/Extensions/JukeboxHelpers/OEmbed.py
+++ b/Extensions/JukeboxHelpers/OEmbed.py
@@ -1,0 +1,40 @@
+import aiohttp
+import logging
+from urllib.parse import quote
+
+log = logging.getLogger(__name__)
+
+
+class OEmbedFetchError(Exception):
+    """Raised when oEmbed fetch fails."""
+    pass
+
+
+async def fetch_youtube_oembed(url: str) -> dict:
+    """
+    Fetch title and author from YouTube's oEmbed API.
+
+    Args:
+        url: A YouTube video URL (e.g., https://youtube.com/watch?v=xxx)
+
+    Returns:
+        dict with 'title' and 'author' keys
+
+    Raises:
+        OEmbedFetchError: If the fetch fails for any reason
+    """
+    oembed_url = f"https://www.youtube.com/oembed?url={quote(url, safe='')}&format=json"
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(oembed_url) as response:
+                if response.status != 200:
+                    raise OEmbedFetchError(f"oEmbed fetch failed with status {response.status}")
+
+                data = await response.json()
+                return {
+                    "title": data.get("title"),
+                    "author": data.get("author_name")
+                }
+    except aiohttp.ClientError as e:
+        raise OEmbedFetchError(f"Network error: {e}") from e

--- a/Extensions/JukeboxHelpers/OEmbed.py
+++ b/Extensions/JukeboxHelpers/OEmbed.py
@@ -25,9 +25,14 @@ async def fetch_youtube_oembed(url: str) -> dict:
     """
     oembed_url = f"https://www.youtube.com/oembed?url={quote(url, safe='')}&format=json"
 
+    print(oembed_url)
+
     try:
         async with aiohttp.ClientSession() as session:
             async with session.get(oembed_url) as response:
+                
+                print(response)
+                
                 if response.status != 200:
                     raise OEmbedFetchError(f"oEmbed fetch failed with status {response.status}")
 

--- a/Extensions/JukeboxHelpers/OEmbed.py
+++ b/Extensions/JukeboxHelpers/OEmbed.py
@@ -25,21 +25,36 @@ async def fetch_youtube_oembed(url: str) -> dict:
     """
     oembed_url = f"https://www.youtube.com/oembed?url={quote(url, safe='')}&format=json"
 
-    print(oembed_url)
+    log.info(f"[OEmbed] Fetching oEmbed for URL: {url}")
+    log.info(f"[OEmbed] Constructed oEmbed URL: {oembed_url}")
 
     try:
+        log.info("[OEmbed] Creating aiohttp session...")
         async with aiohttp.ClientSession() as session:
+            log.info("[OEmbed] Sending GET request...")
             async with session.get(oembed_url) as response:
-                
-                print(response)
-                
-                if response.status != 200:
-                    raise OEmbedFetchError(f"oEmbed fetch failed with status {response.status}")
+                log.info(f"[OEmbed] Response status: {response.status}")
+                log.info(f"[OEmbed] Response headers: {dict(response.headers)}")
 
-                data = await response.json()
-                return {
+                if response.status != 200:
+                    body = await response.text()
+                    log.error(f"[OEmbed] Non-200 response body: {body[:500]}")
+                    raise OEmbedFetchError(f"oEmbed fetch failed with status {response.status}: {body[:200]}")
+
+                raw_body = await response.text()
+                log.info(f"[OEmbed] Raw response body: {raw_body[:500]}")
+
+                import json
+                data = json.loads(raw_body)
+                result = {
                     "title": data.get("title"),
                     "author": data.get("author_name")
                 }
+                log.info(f"[OEmbed] Parsed result: {result}")
+                return result
     except aiohttp.ClientError as e:
+        log.exception(f"[OEmbed] aiohttp ClientError: {e}")
         raise OEmbedFetchError(f"Network error: {e}") from e
+    except Exception as e:
+        log.exception(f"[OEmbed] Unexpected error: {type(e).__name__}: {e}")
+        raise OEmbedFetchError(f"Unexpected error: {type(e).__name__}: {e}") from e

--- a/Extensions/JukeboxHelpers/OEmbed.py
+++ b/Extensions/JukeboxHelpers/OEmbed.py
@@ -27,41 +27,29 @@ async def fetch_youtube_oembed(url: str) -> dict:
     """
     oembed_url = f"https://www.youtube.com/oembed?url={quote(url, safe='')}&format=json"
 
-    log.info(f"[OEmbed] Fetching oEmbed for URL: {url}")
-    log.info(f"[OEmbed] Constructed oEmbed URL: {oembed_url}")
-
     try:
-        log.info("[OEmbed] Creating aiohttp session...")
         timeout = aiohttp.ClientTimeout(total=10)
         connector = aiohttp.TCPConnector(family=socket.AF_INET)  # Force IPv4
         async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
-            log.info("[OEmbed] Sending GET request (10s timeout)...")
             async with session.get(oembed_url) as response:
-                log.info(f"[OEmbed] Response status: {response.status}")
-                log.info(f"[OEmbed] Response headers: {dict(response.headers)}")
-
                 if response.status != 200:
                     body = await response.text()
-                    log.error(f"[OEmbed] Non-200 response body: {body[:500]}")
-                    raise OEmbedFetchError(f"oEmbed fetch failed with status {response.status}: {body[:200]}")
+                    log.error(f"[OEmbed] Failed with status {response.status}: {body[:200]}")
+                    raise OEmbedFetchError(f"oEmbed fetch failed with status {response.status}")
 
-                raw_body = await response.text()
-                log.info(f"[OEmbed] Raw response body: {raw_body[:500]}")
-
-                import json
-                data = json.loads(raw_body)
-                result = {
+                data = await response.json()
+                return {
                     "title": data.get("title"),
                     "author": data.get("author_name")
                 }
-                log.info(f"[OEmbed] Parsed result: {result}")
-                return result
     except asyncio.TimeoutError as e:
-        log.exception("[OEmbed] Request timed out after 10 seconds")
-        raise OEmbedFetchError("Request timed out after 10 seconds") from e
+        log.error("[OEmbed] Request timed out")
+        raise OEmbedFetchError("Request timed out") from e
     except aiohttp.ClientError as e:
-        log.exception(f"[OEmbed] aiohttp ClientError: {e}")
+        log.error(f"[OEmbed] Network error: {e}")
         raise OEmbedFetchError(f"Network error: {e}") from e
+    except OEmbedFetchError:
+        raise
     except Exception as e:
-        log.exception(f"[OEmbed] Unexpected error: {type(e).__name__}: {e}")
-        raise OEmbedFetchError(f"Unexpected error: {type(e).__name__}: {e}") from e
+        log.error(f"[OEmbed] Unexpected error: {type(e).__name__}: {e}")
+        raise OEmbedFetchError(f"Unexpected error: {e}") from e

--- a/FeatureFlags.py
+++ b/FeatureFlags.py
@@ -1,0 +1,92 @@
+"""
+Feature flags!
+This all started since I need a workaround for playing YT vids with lavalink via URLs :P
+"""
+
+import json
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+class FeatureFlags:
+
+	# Hardcoded flags
+	DEFAULTS = {"yt_url_workaround": False}
+
+	def __init__(self, config_path: str = "Assets/feature_flags.json"):
+		self.config_path = Path(config_path)
+		self.flags = {}
+		self._load()
+
+	def _load(self):
+		"""
+		Load flag states persisted in file
+		"""
+		self.flags = self.DEFAULTS.copy()
+
+		if self.config_path.exists():
+			try:
+				with open(self.config_path, "r") as f:
+					persisted_flag_states = json.load(f)
+					self.flags.update(persisted_flag_states)
+			except Exception as e:
+				log.warning(f"Failed to load feature flags: {e}")
+
+		self._save()
+		
+		log.info("Feature flags loaded: {}".format(self.flags))
+
+	def _save(self):
+		with open(self.config_path, "w") as file:
+			json.dump(self.flags, file, indent=2)
+
+	def enable(self, flag: str) -> bool:
+		"""
+		Enables a flag. Returns whether a flag exists
+		"""
+		if flag not in self.DEFAULTS:
+			return False
+
+		self.flags[flag] = True
+
+		# persist
+		self._save()
+
+		return True
+
+	def disable(self, flag: str) -> bool:
+		"""
+		Disables a flag. Returns whether a flag exists
+		"""
+		if flag not in self.DEFAULTS:
+			return False
+
+		self.flags[flag] = False
+
+		# persist
+		self._save()
+
+		return True
+
+	def toggle(self, flag: str) -> bool | None:
+		"""
+		Disables a flag. Returns the flag's new state
+		(or None if flag does not exist)
+		"""
+		if flag not in self.DEFAULTS:
+			return None
+
+		self.flags[flag] = not self.flags[flag]
+
+		# persist
+		self._save()
+
+		return self.flags[flag]
+
+	def list_all(self) -> dict[str, bool]:
+		return self.flags.copy()
+	
+	def is_enabled(self, flag: str) -> bool:
+		return self.flags[flag] if self.flags[flag] else False

--- a/Replies/Strings.py
+++ b/Replies/Strings.py
@@ -43,6 +43,7 @@ class Messages:
     JUKEBOX_NO_VOICE_CHANNEL = ":question: 我不知道你在哪裡QQ"
     JUKEBOX_ALREADY_CONNECTED = ":question: 我已經加入語音頻道囉？"
     JUKEBOX_SEARCHING = ":mag: 正在搜尋：`{}`"
+    JUKEBOX_SEARCHING_WORKAROUND = ":mag: 正在搜尋：~~`{}`~~ ➡️ `{}`"
     JUKEBOX_NO_MATCHES = ":x: 搜尋結果為空。"
     JUKEBOX_SKIPPED = ":track_next: 跳過！"
     JUKEBOX_LOOP_ONE_DISABLED_AUTO = ":arrow_right: 已自動停用單曲循環播放。"

--- a/Replies/Strings.py
+++ b/Replies/Strings.py
@@ -68,6 +68,9 @@ class Messages:
     FEATURE_FLAG_NOT_FOUND = "找不到功能：`{}`。"
     FEATURE_FLAG_STATE = "功能 `{}` 啟用狀態已更新為： {}"
 
+    # YT URL workaround
+    YT_WORKAROUND_OEMBED_FETCH_FAILED = ":pleading_face: 取得影片資訊失敗。將嘗試使用原網址搜尋。"
+
 
 class EmbedStrings:
     """

--- a/Replies/Strings.py
+++ b/Replies/Strings.py
@@ -62,6 +62,12 @@ class Messages:
     ABOUT_FOOTER = "SUICA v{} • 使用 discord.py 及 wavelink 開發。"
     ABOUT_TITLE = "關於 SUICA"
 
+    # Feature flags
+    FEATURE_FLAG_ON = "已啟用 `{}`。"
+    FEATURE_FLAG_OFF = "已停用 `{}`。"
+    FEATURE_FLAG_NOT_FOUND = "找不到功能：`{}`。"
+    FEATURE_FLAG_STATE = "功能 `{}` 啟用狀態已更新為： {}"
+
 
 class EmbedStrings:
     """

--- a/Suica.py
+++ b/Suica.py
@@ -5,6 +5,7 @@ import pkgutil
 from discord.ext import commands
 
 import Extensions
+from FeatureFlags import FeatureFlags
 from Replies.Strings import Messages
 
 log = logging.getLogger(__name__)
@@ -24,8 +25,11 @@ class Bot(commands.Bot):
         self.token = ""
         self.backstage_channel = None
         self.prefix = "."
-        self.version = "3.1.3"
+        self.version = "3.1.3a"
         self.status_message = ""
+        self.feature_flags = {}
+
+        self.feature_flags = FeatureFlags()
 
         # Load configuration from config.json
         try:
@@ -54,7 +58,7 @@ class Bot(commands.Bot):
 
         # Setup intents as they are required in 2.0
         intents = discord.Intents.default()
-        intents.message_content = True
+        intents.message_content = True        
 
         # Init the bot after setting the token and prefix
         self.token = config["token"]


### PR DESCRIPTION
Looks like youtube doesn't like us querying videos directly with URLs with our VMs in the cloud.
Workaround: grab title + uploader from YT's OEmbed and use it as the query instead of the raw URL. 90% of the time we'd get the same video.
A simple feature flag system's also implemented to toggle this workaround.